### PR TITLE
Update gdal imports for Windows

### DIFF
--- a/code/CropSimulation.py
+++ b/code/CropSimulation.py
@@ -6,7 +6,11 @@ Written by N. Lakmal Deshapriya
 import numpy as np
 import matplotlib.pyplot as plt
 import imageio
-import gdal
+try: 
+    import gdal
+except ImportError:
+    from osgeo import gdal
+ 
 
 import UtilitiesCalc
 import BioMassCalc

--- a/code/UtilitiesCalc.py
+++ b/code/UtilitiesCalc.py
@@ -5,7 +5,10 @@ Written by N. Lakmal Deshapriya
 
 import numpy as np
 from scipy.interpolate import interp1d
-import gdal
+try:
+    import gdal
+except ImportError:
+    from osgeo import gdal
 
 class UtilitiesCalc(object):
 


### PR DESCRIPTION
I am testing this on Windows, and the way gdal is imported is usually through `from osgeo import gdal` - I added a try/except block to catch this import and re-try for the Windows-style import. 