### PR TITLE
3 fixes to ClimateRegime.py

### DIFF
--- a/pyaez/ClimateRegime.py
+++ b/pyaez/ClimateRegime.py
@@ -1157,7 +1157,7 @@ class ClimateRegime(object):
     according to Gunther's agreement and the documentation.
     """
          
-    def getMultiCroppingZones(self, t_climate, lgp, lgp_t5, lgp_t10, ts_t10, ts_t0):
+    def getMultiCroppingZones(self, t_climate, lgp, lgp_t5, lgp_t10, ts_t0, ts_t10):
         
         # defining the constant arrays for rainfed and irrigated conditions, all pixel values start with 1
         multi_crop_rain = np.zeros((self.im_height, self.im_width), dtype = int) # all values started with Zone A

--- a/pyaez/ClimateRegime.py
+++ b/pyaez/ClimateRegime.py
@@ -473,8 +473,6 @@ class ClimateRegime(object):
         #============================
         Txsnm = 0.  # Txsnm - snow melt temperature threshold
         Fsnm = 5.5  # Fsnm - snow melting coefficient
-        Sb_old = 0.
-        Wb_old = 0.
         #============================
         Tx365 = self.maxT_daily.copy()
         Ta365 = self.meanT_daily.copy()
@@ -492,6 +490,8 @@ class ClimateRegime(object):
         #============================
         for i_row in range(self.im_height):
             for i_col in range(self.im_width):
+                Sb_old = 0.
+                Wb_old = 0.                
 
                 lgpt5_point = self.lgpt5[i_row, i_col]
 

--- a/pyaez/ClimateRegime.py
+++ b/pyaez/ClimateRegime.py
@@ -986,11 +986,11 @@ class ClimateRegime(object):
                             aez[i_r, i_c] = 53
 
                         # BO/Cold climate, with Permafrost
-                        elif aez_temp_regime[i_r, i_c] == 9 and aez_moisture_regime[i_r, i_c] in [1, 2, 3, 4] == True:
+                        elif aez_temp_regime[i_r, i_c] == 9 and (aez_moisture_regime[i_r, i_c] in [1, 2, 3, 4]) == True:
                             aez[i_r, i_c] = 54
 
                         # Arctic/ Very cold climate
-                        elif aez_temp_regime[i_r, i_c] == 10 and aez_moisture_regime[i_r, i_c] in [1, 2, 3, 4] == True:
+                        elif aez_temp_regime[i_r, i_c] == 10 and (aez_moisture_regime[i_r, i_c] in [1, 2, 3, 4]) == True:
                             aez[i_r, i_c] = 55
 
                         # Severe soil/terrain limitations

--- a/pyaez/LGPCalc.py
+++ b/pyaez/LGPCalc.py
@@ -331,6 +331,8 @@ def EtaCalc(Tx365, Ta365, Pcp365, Txsnm, Fsnm, Eto365, wb_old, sb_old, doy, ista
             Eta365 = etm
         else:
             Eta365 = Eta
+
+        sbx = sb_old-snm
             
         Wb365 = wb
         Wx365 = wx


### PR DESCRIPTION
Hey guys. I've been working on a sped up version of module 1 and comparing it's outputs to the outputs of the repo model version. During this process I've found a few bugs in the repo version of pyaez. They are in ClimateRegime.py:

1) in getLGP. The initialization of Sb_old and Wb_old to zero for each grid cell needs to be moved inside the spatial loops for the zero initialization to work as intended. Otherwise, the Sb_old and Wb_old will initialize to the new bucket values for the previous grid cell.

2) in AEZClassification. This is a weird one, but there are two conditional statements in this function that aren't working as intended and python will not throw an error in this case. The problem arises when using 'variable[row,col] in [val1,val2,val3,val4]' in an 'elif' conditional statement. This part of the condition needs to be enclosed in parentheses or the statement won't work as intended.

3) in getMultiCroppingZones. The order of the inputs in the function does not match the order of the inputs in the notebook. I've updated the order in the .py file instead of the notebook. It's the last two inputs that are the offenders ts_t0 and ts_t10.